### PR TITLE
Fixes #1

### DIFF
--- a/ClassDiagram.puml
+++ b/ClassDiagram.puml
@@ -1,38 +1,9 @@
 @startuml
-namespace main {
-    class NewParser << (S,Aquamarine) >> {
-    }
-}
-parser.ClassParser *-- main.NewParser
-
-
 namespace parser {
-    class Struct << (S,Aquamarine) >> {
-        + PackageName string
-        + Functions []Function
-        + Fields []Field
-        + Type string
-        + Composition []string
-        + Extends []string
-
-        + ImplementsInterface(inter Struct) 
-        + AddToComposition(fType string) 
-        + AddToExtends(fType string) 
-        + AddField(field ast.Field, aliases <font color=blue>map</font>[string]string) 
-        + AddMethod(method ast.Field, aliases <font color=blue>map</font>[string]string) 
-
-    }
-    class Function << (S,Aquamarine) >> {
-        + Name string
-        + Parameters []Field
-        + ReturnValues []string
-
-        + SignturesAreEqual(function Function) 
-
-    }
     class Field << (S,Aquamarine) >> {
         + Name string
         + Type string
+        + FullType string
 
     }
     class LineStringBuilder << (S,Aquamarine) >> {
@@ -40,26 +11,51 @@ namespace parser {
 
     }
     class ClassParser << (S,Aquamarine) >> {
-        - structure <font color=blue>map</font>[string]<font color=blue>map</font>[string]Struct
+        - structure <font color=blue>map</font>[string]<font color=blue>map</font>[string]*Struct
         - currentPackageName string
         - allInterfaces <font color=blue>map</font>[string]<font color=blue>struct</font>{}
         - allStructs <font color=blue>map</font>[string]<font color=blue>struct</font>{}
         - allImports <font color=blue>map</font>[string]string
 
         - parsePackage(node ast.Node) 
-        - parseImports(impt ast.ImportSpec) 
-        - parseDirectory(directoryPath string) 
+        - parseImports(impt *ast.ImportSpec) 
+        - parseDirectory(directoryPath string) {packageName}error
         - parseFileDeclarations(node ast.Decl) 
-        - renderStructures(pack string, structures <font color=blue>map</font>[string]Struct, str LineStringBuilder) 
-        - renderStructure(structure Struct, pack string, name string, str LineStringBuilder, composition LineStringBuilder, extends LineStringBuilder) 
-        - renderCompositions(structure Struct, name string, composition LineStringBuilder) 
-        - renderExtends(structure Struct, name string, extends LineStringBuilder) 
-        - renderStructMethods(structure Struct, privateMethods LineStringBuilder, publicMethods LineStringBuilder) 
-        - renderStructFields(structure Struct, privateFields LineStringBuilder, publicFields LineStringBuilder) 
-        - getOrCreateStruct(name string) 
-        - getStruct(structName string) 
+        - renderStructures(pack string, structures <font color=blue>map</font>[string]*{packageName}Struct, str *{packageName}LineStringBuilder) 
+        - renderStructure(structure *{packageName}Struct, pack string, name string, str *{packageName}LineStringBuilder, composition *{packageName}LineStringBuilder, extends *{packageName}LineStringBuilder) 
+        - renderCompositions(structure *{packageName}Struct, name string, composition *{packageName}LineStringBuilder) 
+        - renderExtends(structure *{packageName}Struct, name string, extends *{packageName}LineStringBuilder) 
+        - renderStructMethods(structure *{packageName}Struct, privateMethods *{packageName}LineStringBuilder, publicMethods *{packageName}LineStringBuilder) 
+        - renderStructFields(structure *{packageName}Struct, privateFields *{packageName}LineStringBuilder, publicFields *{packageName}LineStringBuilder) 
+        - getOrCreateStruct(name string) *{packageName}Struct
+        - getStruct(structName string) *{packageName}Struct
 
-        + Render() 
+        + Render() string
+
+    }
+    class Struct << (S,Aquamarine) >> {
+        + PackageName string
+        + Functions []*Function
+        + Fields []*Field
+        + Type string
+        + Composition <font color=blue>map</font>[string]<font color=blue>struct</font>{}
+        + Extends <font color=blue>map</font>[string]<font color=blue>struct</font>{}
+
+        + ImplementsInterface(inter *{packageName}Struct) bool
+        + AddToComposition(fType string) 
+        + AddToExtends(fType string) 
+        + AddField(field *ast.Field, aliases <font color=blue>map</font>[string]string) 
+        + AddMethod(method *ast.Field, aliases <font color=blue>map</font>[string]string) 
+
+    }
+    class Function << (S,Aquamarine) >> {
+        + Name string
+        + Parameters []*Field
+        + ReturnValues []string
+        + PackageName string
+        + FullNameReturnValues []string
+
+        + SignturesAreEqual(function *{packageName}Function) bool
 
     }
 }

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -92,8 +92,8 @@ func TestGetOrCreateStruct(t *testing.T) {
 					Functions:   make([]*Function, 0),
 					Fields:      make([]*Field, 0),
 					Type:        "",
-					Composition: make([]string, 0),
-					Extends:     make([]string, 0),
+					Composition: make(map[string]struct{}, 0),
+					Extends:     make(map[string]struct{}, 0),
 				}) {
 					t.Errorf("Expected resulting structure to be equal to %v, got %v", tc.structure, st)
 				}

--- a/parser/struct.go
+++ b/parser/struct.go
@@ -64,17 +64,20 @@ func (st *Struct) AddToExtends(fType string) {
 //AddField adds a field into this structure. It parses the ast.Field and extract all
 //needed information
 func (st *Struct) AddField(field *ast.Field, aliases map[string]string) {
+	theType := getFieldType(field.Type, aliases)
+	theType = replacePackageConstant(theType, "")
 	if field.Names != nil {
+		theType := getFieldType(field.Type, aliases)
+		theType = replacePackageConstant(theType, "")
 		st.Fields = append(st.Fields, &Field{
 			Name: field.Names[0].Name,
-			Type: getFieldType(field.Type, aliases),
+			Type: theType,
 		})
 	} else if field.Type != nil {
-		fType := getFieldType(field.Type, aliases)
-		if fType[0] == "*"[0] {
-			fType = fType[1:]
+		if theType[0] == "*"[0] {
+			theType = theType[1:]
 		}
-		st.AddToComposition(fType)
+		st.AddToComposition(theType)
 	}
 }
 
@@ -84,6 +87,6 @@ func (st *Struct) AddMethod(method *ast.Field, aliases map[string]string) {
 	if !ok {
 		return
 	}
-	function := getFunction(f, method.Names[0].Name, aliases)
+	function := getFunction(f, method.Names[0].Name, aliases, st.PackageName)
 	st.Functions = append(st.Functions, function)
 }

--- a/parser/struct_test.go
+++ b/parser/struct_test.go
@@ -296,10 +296,10 @@ func TestAddToExtension(t *testing.T) {
 	}
 }
 
-func arrayContains(a []string, text string) bool {
+func arrayContains(a map[string]struct{}, text string) bool {
 
 	found := false
-	for _, v := range a {
+	for v := range a {
 		if v == text {
 			found = true
 			break


### PR DESCRIPTION
Supported compiling of fullnames while the function signature is being generated so that we can make the comparison for the interfaces using the full names and not the local names. This allows us to keep the local name for the rendering as well.