### PR TITLE
Fixes #13

### DIFF
--- a/parser/function.go
+++ b/parser/function.go
@@ -43,16 +43,16 @@ func getFunction(f *ast.FuncType, name string, aliases map[string]string, packag
 	params := f.Params
 	if params != nil {
 		for _, pa := range params.List {
-			fieldName := ""
-			if pa.Names != nil {
-				fieldName = pa.Names[0].Name
-			}
 			theType := getFieldType(pa.Type, aliases)
-			function.Parameters = append(function.Parameters, &Field{
-				Name:     fieldName,
-				Type:     replacePackageConstant(theType, ""),
-				FullType: replacePackageConstant(theType, packageName),
-			})
+			if pa.Names != nil {
+				for _, fieldName := range pa.Names {
+					function.Parameters = append(function.Parameters, &Field{
+						Name:     fieldName.Name,
+						Type:     replacePackageConstant(theType, ""),
+						FullType: replacePackageConstant(theType, packageName),
+					})
+				}
+			}
 		}
 	}
 

--- a/parser/function_test.go
+++ b/parser/function_test.go
@@ -1,0 +1,108 @@
+package parser
+
+import (
+	"go/ast"
+	"reflect"
+	"testing"
+)
+
+func TestgetFunction(t *testing.T) {
+
+	tt := []struct {
+		Name           string
+		Func           *ast.FuncType
+		ExpectedResult *Function
+		FunctionName   string
+	}{
+		{
+			Name: "Function with to typed parameters",
+			Func: &ast.FuncType{
+				Params: &ast.FieldList{
+					List: []*ast.Field{
+						{
+							Names: []*ast.Ident{
+								{
+									Name: "param1",
+								},
+							},
+							Type: &ast.Ident{
+								Name: "int",
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: &Function{
+				Name: "TestFunction",
+				Parameters: []*Field{
+					{
+						Name:     "param1",
+						Type:     "int",
+						FullType: "int",
+					},
+				},
+			},
+			FunctionName: "TestFunction",
+		},
+		{
+			Name:           "Function with to parameters only one typed",
+			Func:           &ast.FuncType{},
+			ExpectedResult: &Function{},
+			FunctionName:   "TestFunction",
+		},
+		{
+			Name: "Function with to typed parameters",
+			Func: &ast.FuncType{
+				Params: &ast.FieldList{
+					List: []*ast.Field{
+						{
+							Names: []*ast.Ident{
+								{
+									Name: "param1",
+								},
+								{
+									Name: "param2i",
+								},
+							},
+							Type: &ast.Ident{
+								Name: "int",
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: &Function{
+				Name: "TestFunction",
+				Parameters: []*Field{
+					{
+						Name:     "param1",
+						Type:     "int",
+						FullType: "int",
+					},
+					{
+						Name:     "param2",
+						Type:     "int",
+						FullType: "int",
+					},
+				},
+			},
+			FunctionName: "TestFunction",
+		},
+		{
+			Name:           "Function with to parameters only one typed",
+			Func:           &ast.FuncType{},
+			ExpectedResult: &Function{},
+			FunctionName:   "TestFunction",
+		},
+	}
+
+	for _, tc := range tt {
+		function := getFunction(tc.Func, tc.FunctionName, map[string]string{
+			"main": "main",
+		}, "main")
+
+		if !reflect.DeepEqual(function, tc.ExpectedResult) {
+			t.Errorf("Expected function to be %v, got %v", tc.ExpectedResult, function)
+		}
+	}
+}


### PR DESCRIPTION
Added support for omitted types in the parameters of a function.
This fixes the issue in which we were not recognizing the signatures to be equal in to functions because the omitted type parameters were not being considered as part of the parameters