### PR TITLE
Enhancement: Proposal to pass multiple subfolder in a folder

### DIFF
--- a/ClassDiagram.puml
+++ b/ClassDiagram.puml
@@ -1,21 +1,15 @@
+int - testingsupport.myInt
 @startuml
+namespace subfolder2 {
+    class Subfolder2 << (S,Aquamarine) >> {
+        + SubfolderFunction() bool
+
+    }
+}
+
+subfolder.SubfolderInterface <|-- subfolder2.Subfolder2
+
 namespace parser {
-    class Function << (S,Aquamarine) >> {
-        + Name string
-        + Parameters []*Field
-        + ReturnValues []string
-        + PackageName string
-        + FullNameReturnValues []string
-
-        + SignturesAreEqual(function *Function) bool
-
-    }
-    class Field << (S,Aquamarine) >> {
-        + Name string
-        + Type string
-        + FullType string
-
-    }
     class LineStringBuilder << (S,Aquamarine) >> {
         + WriteLineWithDepth(depth int, str string) 
 
@@ -26,6 +20,7 @@ namespace parser {
         - allInterfaces <font color=blue>map</font>[string]<font color=blue>struct</font>{}
         - allStructs <font color=blue>map</font>[string]<font color=blue>struct</font>{}
         - allImports <font color=blue>map</font>[string]string
+        - allAliases <font color=blue>map</font>[string]*Alias
 
         - parsePackage(node ast.Node) 
         - parseImports(impt *ast.ImportSpec) 
@@ -34,6 +29,7 @@ namespace parser {
         - renderStructures(pack string, structures <font color=blue>map</font>[string]*Struct, str *LineStringBuilder) 
         - renderStructure(structure *Struct, pack string, name string, str *LineStringBuilder, composition *LineStringBuilder, extends *LineStringBuilder) 
         - renderCompositions(structure *Struct, name string, composition *LineStringBuilder) 
+        - getPackageName(t string, st *Struct) string
         - renderExtends(structure *Struct, name string, extends *LineStringBuilder) 
         - renderStructMethods(structure *Struct, privateMethods *LineStringBuilder, publicMethods *LineStringBuilder) 
         - renderStructFields(structure *Struct, privateFields *LineStringBuilder, publicFields *LineStringBuilder) 
@@ -41,6 +37,18 @@ namespace parser {
         - getStruct(structName string) *Struct
 
         + Render() string
+
+    }
+    class Field << (S,Aquamarine) >> {
+        + Name string
+        + Type string
+        + FullType string
+
+    }
+    class Alias << (S,Aquamarine) >> {
+        + Name string
+        + PackageName string
+        + AliasOf string
 
     }
     class Struct << (S,Aquamarine) >> {
@@ -58,8 +66,44 @@ namespace parser {
         + AddMethod(method *ast.Field, aliases <font color=blue>map</font>[string]string) 
 
     }
+    class Function << (S,Aquamarine) >> {
+        + Name string
+        + Parameters []*Field
+        + ReturnValues []string
+        + PackageName string
+        + FullNameReturnValues []string
+
+        + SignturesAreEqual(function *Function) bool
+
+    }
 }
 strings.Builder *-- parser.LineStringBuilder
 
 
+namespace testingsupport {
+    class test << (S,Aquamarine) >> {
+        - field int
+
+        - test() 
+
+    }
+    class testingsupport.myInt << (T, #FF7700) >>  {
+    }
+}
+
+subfolder.test2 <|-- testingsupport.test
+
+namespace subfolder {
+    interface test2  {
+        - test() 
+
+    }
+    interface SubfolderInterface  {
+        + SubfolderFunction() bool
+
+    }
+}
+
+
+__builtin__.int #.. testingsupport.myInt
 @enduml

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ This will install the command goplantuml in your GOPATH bin folder.
 ### Usage
 
 ```
-goplantuml [-recursive] path/to/gofiles
+goplantuml [-recursive] path/to/gofiles path/to/gofiles2
 ```
 ```
-goplantuml [-recursive] path/to/gofiles > diagram_file_name.puml
+goplantuml [-recursive] path/to/gofiles path/to/gofiles2 > diagram_file_name.puml
 ```
 
 #### Example

--- a/parser/class_parser.go
+++ b/parser/class_parser.go
@@ -54,7 +54,7 @@ type ClassParser struct {
 
 //NewClassDiagram returns a new classParser with which can Render the class diagram of
 // files int eh given directory
-func NewClassDiagram(directoryPath string, recursive bool) (*ClassParser, error) {
+func NewClassDiagram(directoryPaths []string, recursive bool) (*ClassParser, error) {
 	classParser := &ClassParser{
 		structure:     make(map[string]map[string]*Struct),
 		allInterfaces: make(map[string]struct{}),
@@ -62,26 +62,28 @@ func NewClassDiagram(directoryPath string, recursive bool) (*ClassParser, error)
 		allImports:    make(map[string]string),
 		allAliases:    make(map[string]*Alias),
 	}
-	if recursive {
-		err := filepath.Walk(directoryPath, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if info.IsDir() {
-				if strings.HasPrefix(info.Name(), ".") || info.Name() == "vendor" {
-					return filepath.SkipDir
+	for _, directoryPath := range directoryPaths {
+		if recursive {
+			err := filepath.Walk(directoryPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
 				}
-				classParser.parseDirectory(path)
+				if info.IsDir() {
+					if strings.HasPrefix(info.Name(), ".") || info.Name() == "vendor" {
+						return filepath.SkipDir
+					}
+					classParser.parseDirectory(path)
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, err
 			}
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err := classParser.parseDirectory(directoryPath)
-		if err != nil {
-			return nil, err
+		} else {
+			err := classParser.parseDirectory(directoryPath)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -467,7 +467,7 @@ func TestNewClassDiagram(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			parser, err := NewClassDiagram(tc.Path, tc.Recursive)
+			parser, err := NewClassDiagram([]string{tc.Path}, tc.Recursive)
 
 			if tc.ExpectedError != "" {
 				if err == nil {
@@ -502,7 +502,7 @@ func TestNewClassDiagram(t *testing.T) {
 
 func TestRender(t *testing.T) {
 
-	parser, err := NewClassDiagram("../testingsupport", false)
+	parser, err := NewClassDiagram([]string{"../testingsupport"}, false)
 	if err != nil {
 		t.Errorf("TestRender: expected no errors, got %s", err.Error())
 		return
@@ -527,5 +527,24 @@ func TestGetPackageName(t *testing.T) {
 	ty := p.getPackageName("int", s)
 	if ty != builtinPackageName {
 		t.Errorf("TestGetPackageName: expecting [%s], got [%s]", builtinPackageName, ty)
+	}
+}
+
+func TestMultipleFolders(t *testing.T) {
+	parser, err := NewClassDiagram([]string{"../testingsupport/subfolder", "../testingsupport/subfolder2"}, false)
+
+	if err != nil {
+		t.Errorf("TestMultipleFolders: expected no errors, got %s", err.Error())
+		return
+	}
+
+	resultRender := parser.Render()
+	result, err := ioutil.ReadFile("../testingsupport/subfolder1-2.puml")
+	if err != nil {
+		t.Errorf("TestMultipleFolders: expected no errors reading testing file, got %s", err.Error())
+	}
+	resultAlt, err := ioutil.ReadFile("../testingsupport/subfolder1-2alt.puml")
+	if string(result) != resultRender && string(resultAlt) != resultRender {
+		t.Errorf("TestMultipleFolders: Expected renders to be the same as %s or %s, but got %s", result, resultAlt, resultRender)
 	}
 }

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -531,7 +531,7 @@ func TestGetPackageName(t *testing.T) {
 }
 
 func TestMultipleFolders(t *testing.T) {
-	parser, err := NewClassDiagram([]string{"../testingsupport/subfolder", "../testingsupport/subfolder2"}, false)
+	parser, err := NewClassDiagram([]string{"../testingsupport/subfolder3", "../testingsupport/subfolder2"}, false)
 
 	if err != nil {
 		t.Errorf("TestMultipleFolders: expected no errors, got %s", err.Error())

--- a/testingsupport/subfolder/subfolder.go
+++ b/testingsupport/subfolder/subfolder.go
@@ -3,3 +3,7 @@ package subfolder
 type test2 interface {
 	test()
 }
+
+type SubfolderInterface interface {
+	SubfolderFunction(bool, int) bool
+}

--- a/testingsupport/subfolder/subfolder.go
+++ b/testingsupport/subfolder/subfolder.go
@@ -3,7 +3,3 @@ package subfolder
 type test2 interface {
 	test()
 }
-
-type SubfolderInterface interface {
-	SubfolderFunction(bool, int) bool
-}

--- a/testingsupport/subfolder1-2.puml
+++ b/testingsupport/subfolder1-2.puml
@@ -1,0 +1,23 @@
+@startuml
+namespace subfolder {
+    interface test2  {
+        - test() 
+
+    }
+    interface SubfolderInterface  {
+        + SubfolderFunction() bool
+
+    }
+}
+
+
+namespace subfolder2 {
+    class Subfolder2 << (S,Aquamarine) >> {
+        + SubfolderFunction() bool
+
+    }
+}
+
+subfolder.SubfolderInterface <|-- subfolder2.Subfolder2
+
+@enduml

--- a/testingsupport/subfolder1-2.puml
+++ b/testingsupport/subfolder1-2.puml
@@ -1,9 +1,5 @@
 @startuml
-namespace subfolder {
-    interface test2  {
-        - test() 
-
-    }
+namespace subfolder3 {
     interface SubfolderInterface  {
         + SubfolderFunction() bool
 
@@ -18,6 +14,6 @@ namespace subfolder2 {
     }
 }
 
-subfolder.SubfolderInterface <|-- subfolder2.Subfolder2
+subfolder3.SubfolderInterface <|-- subfolder2.Subfolder2
 
 @enduml

--- a/testingsupport/subfolder1-2alt.puml
+++ b/testingsupport/subfolder1-2alt.puml
@@ -6,13 +6,9 @@ namespace subfolder2 {
     }
 }
 
-subfolder.SubfolderInterface <|-- subfolder2.Subfolder2
+subfolder3.SubfolderInterface <|-- subfolder2.Subfolder2
 
-namespace subfolder {
-    interface test2  {
-        - test() 
-
-    }
+namespace subfolder3 {
     interface SubfolderInterface  {
         + SubfolderFunction() bool
 

--- a/testingsupport/subfolder1-2alt.puml
+++ b/testingsupport/subfolder1-2alt.puml
@@ -1,0 +1,23 @@
+@startuml
+namespace subfolder2 {
+    class Subfolder2 << (S,Aquamarine) >> {
+        + SubfolderFunction() bool
+
+    }
+}
+
+subfolder.SubfolderInterface <|-- subfolder2.Subfolder2
+
+namespace subfolder {
+    interface test2  {
+        - test() 
+
+    }
+    interface SubfolderInterface  {
+        + SubfolderFunction() bool
+
+    }
+}
+
+
+@enduml

--- a/testingsupport/subfolder2/subfolder2.go
+++ b/testingsupport/subfolder2/subfolder2.go
@@ -1,0 +1,8 @@
+package subfolder2
+
+type Subfolder2 struct {
+}
+
+func (s *Subfolder2) SubfolderFunction(bool, int) bool {
+	return true
+}

--- a/testingsupport/subfolder3/subfolder3.go
+++ b/testingsupport/subfolder3/subfolder3.go
@@ -1,0 +1,5 @@
+package subfolder3
+
+type SubfolderInterface interface {
+	SubfolderFunction(bool, int) bool
+}


### PR DESCRIPTION
Fixes #29

Added capability to the parser to accept an array of strings as the folder directories. Make the parser go through all the given folders in the same way we used to go through one folder before. I also modified the CLI to allow for multiple directories.
Modified the Readme file to have this new information and regenerated the ClassDiagram since now we have added new elements to the testing folders.