### PR TITLE
Struct Fields are not part of the diagram

### DIFF
--- a/ClassDiagram.puml
+++ b/ClassDiagram.puml
@@ -16,7 +16,12 @@ namespace parser {
         + WriteLineWithDepth(depth int, str string) 
 
     }
+    class RenderingOptions << (S,Aquamarine) >> {
+        + Aggregation bool
+
+    }
     class ClassParser << (S,Aquamarine) >> {
+        - renderingOptions *RenderingOptions
         - structure <font color=blue>map</font>[string]<font color=blue>map</font>[string]*Struct
         - currentPackageName string
         - allInterfaces <font color=blue>map</font>[string]<font color=blue>struct</font>{}
@@ -29,8 +34,9 @@ namespace parser {
         - parseDirectory(directoryPath string) error
         - parseFileDeclarations(node ast.Decl) 
         - renderStructures(pack string, structures <font color=blue>map</font>[string]*Struct, str *LineStringBuilder) 
-        - renderStructure(structure *Struct, pack string, name string, str *LineStringBuilder, composition *LineStringBuilder, extends *LineStringBuilder) 
+        - renderStructure(structure *Struct, pack string, name string, str *LineStringBuilder, composition *LineStringBuilder, extends *LineStringBuilder, aggregations *LineStringBuilder) 
         - renderCompositions(structure *Struct, name string, composition *LineStringBuilder) 
+        - renderAggregations(structure *Struct, name string, aggregations *LineStringBuilder) 
         - getPackageName(t string, st *Struct) string
         - renderExtends(structure *Struct, name string, extends *LineStringBuilder) 
         - renderStructMethods(structure *Struct, privateMethods *LineStringBuilder, publicMethods *LineStringBuilder) 
@@ -39,21 +45,7 @@ namespace parser {
         - getStruct(structName string) *Struct
 
         + Render() string
-
-    }
-    class Struct << (S,Aquamarine) >> {
-        + PackageName string
-        + Functions []*Function
-        + Fields []*Field
-        + Type string
-        + Composition <font color=blue>map</font>[string]<font color=blue>struct</font>{}
-        + Extends <font color=blue>map</font>[string]<font color=blue>struct</font>{}
-
-        + ImplementsInterface(inter *Struct) bool
-        + AddToComposition(fType string) 
-        + AddToExtends(fType string) 
-        + AddField(field *ast.Field, aliases <font color=blue>map</font>[string]string) 
-        + AddMethod(method *ast.Field, aliases <font color=blue>map</font>[string]string) 
+        + SetRenderingOptions(ro *RenderingOptions) 
 
     }
     class Function << (S,Aquamarine) >> {
@@ -66,8 +58,29 @@ namespace parser {
         + SignturesAreEqual(function *Function) bool
 
     }
+    class Struct << (S,Aquamarine) >> {
+        + PackageName string
+        + Functions []*Function
+        + Fields []*Field
+        + Type string
+        + Composition <font color=blue>map</font>[string]<font color=blue>struct</font>{}
+        + Extends <font color=blue>map</font>[string]<font color=blue>struct</font>{}
+        + Aggregations <font color=blue>map</font>[string]<font color=blue>struct</font>{}
+
+        + ImplementsInterface(inter *Struct) bool
+        + AddToComposition(fType string) 
+        + AddToExtends(fType string) 
+        + AddToAggregation(fType string) 
+        + AddField(field *ast.Field, aliases <font color=blue>map</font>[string]string) 
+        + AddMethod(method *ast.Field, aliases <font color=blue>map</font>[string]string) 
+
+    }
 }
 strings.Builder *-- parser.LineStringBuilder
 
+
+parser.Function o-- parser.Field
+parser.Struct o-- parser.Function
+parser.Struct o-- parser.Field
 
 @enduml

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ goplantuml [-recursive] path/to/gofiles path/to/gofiles2
 goplantuml [-recursive] path/to/gofiles path/to/gofiles2 > diagram_file_name.puml
 ```
 ```
-goplantuml [-recursive] [-ignore="path/to/ignored/folder1,path/to/ignore/folder2"] path/to/gofiles > diagram_file_name.puml
+goplantuml [-recursive] [-aggregation] [-ignore="path/to/ignored/folder1,path/to/ignore/folder2"] path/to/gofiles > diagram_file_name.puml
 ```
 
 #### Example
@@ -126,6 +126,7 @@ type MyStruct2 struct {
 
 //MyStruct3 will have a foo() function but the return value is not a bool, so it will not have any relationship with MyInterface
 type MyStruct3 struct {
+    Foo MyStruct1
 }
 
 func (s3 *MyStruct3) foo() {
@@ -149,11 +150,15 @@ namespace testingsupport {
     class MyStruct3 << (S,Aquamarine) >> {
         - foo() 
 
+        + Foo MyStruct1
+
     }
 }
 testingsupport.MyStruct1 *-- testingsupport.MyStruct2
 
 testingsupport.MyInterface <|-- testingsupport.MyStruct1
+
+testingsupport.MyStruct3 o-- testingsupport.MyStruct1
 
 @enduml
 ```

--- a/cmd/goplantuml/main.go
+++ b/cmd/goplantuml/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	recursive := flag.Bool("recursive", false, "walk all directories recursively")
 	ignore := flag.String("ignore", "", "comma separated list of folders to ignore")
+	aggregation := flag.Bool("aggregation", false, "renders public aggregations")
 	flag.Parse()
 	dirs, err := getDirectories()
 
@@ -31,6 +32,9 @@ func main() {
 	}
 
 	result, err := goplantuml.NewClassDiagram(dirs, ignoredDirectories, *recursive)
+	result.SetRenderingOptions(&goplantuml.RenderingOptions{
+		Aggregation: *aggregation,
+	})
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/parser/function.go
+++ b/parser/function.go
@@ -43,7 +43,7 @@ func getFunction(f *ast.FuncType, name string, aliases map[string]string, packag
 	params := f.Params
 	if params != nil {
 		for _, pa := range params.List {
-			theType := getFieldType(pa.Type, aliases)
+			theType, _ := getFieldType(pa.Type, aliases)
 			if pa.Names != nil {
 				for _, fieldName := range pa.Names {
 					function.Parameters = append(function.Parameters, &Field{
@@ -59,7 +59,7 @@ func getFunction(f *ast.FuncType, name string, aliases map[string]string, packag
 	results := f.Results
 	if results != nil {
 		for _, pa := range results.List {
-			theType := getFieldType(pa.Type, aliases)
+			theType, _ := getFieldType(pa.Type, aliases)
 			function.ReturnValues = append(function.ReturnValues, replacePackageConstant(theType, ""))
 			function.FullNameReturnValues = append(function.FullNameReturnValues, replacePackageConstant(theType, packageName))
 		}

--- a/parser/struct_test.go
+++ b/parser/struct_test.go
@@ -348,10 +348,11 @@ func TestAddField(t *testing.T) {
 				FullNameReturnValues: []string{"error", "int"},
 			},
 		},
-		Type:        "class",
-		Fields:      make([]*Field, 0),
-		Composition: make(map[string]struct{}),
-		Extends:     make(map[string]struct{}),
+		Type:         "class",
+		Fields:       make([]*Field, 0),
+		Composition:  make(map[string]struct{}),
+		Extends:      make(map[string]struct{}),
+		Aggregations: make(map[string]struct{}),
 	}
 	st.AddField(&ast.Field{
 		Names: []*ast.Ident{
@@ -381,8 +382,24 @@ func TestAddField(t *testing.T) {
 			},
 		},
 	}, make(map[string]string))
+
 	if !arrayContains(st.Composition, "FooComposed") {
 		t.Errorf("TestAddField: Expecting FooComposed to be part of the compositions ,but the array had %v", st.Composition)
+	}
+	st.AddField(&ast.Field{
+		Names: []*ast.Ident{
+			{
+				Name: "Foo",
+			},
+		},
+		Type: &ast.StarExpr{
+			X: &ast.Ident{
+				Name: "FooComposed",
+			},
+		},
+	}, make(map[string]string))
+	if !arrayContains(st.Aggregations, "main.FooComposed") {
+		t.Errorf("TestAddField: Expecting main.FooComposed to be part of the aggregations ,but the array had %v", st.Aggregations)
 	}
 }
 


### PR DESCRIPTION
Fixes #34
Added support for aggregation. This is going to be optional through the use of a RenderOptions struct that could potentially support other things in the future. The CLI also has an optional parameter -aggregation which passes this option to the parser.