### PR TITLE
Extended Interface not correctly visualized

### DIFF
--- a/parser/class_parser.go
+++ b/parser/class_parser.go
@@ -175,7 +175,17 @@ func (p *ClassParser) parseFileDeclarations(node ast.Decl) {
 			case *ast.InterfaceType:
 				declarationType = "interface"
 				for _, f := range c.Methods.List {
-					p.getOrCreateStruct(typeName).AddMethod(f, p.allImports)
+					switch t := f.Type.(type) {
+					case *ast.FuncType:
+						p.getOrCreateStruct(typeName).AddMethod(f, p.allImports)
+						break
+					case *ast.Ident:
+						f, _ := getFieldType(t, p.allImports)
+						st := p.getOrCreateStruct(typeName)
+						f = replacePackageConstant(f, st.PackageName)
+						st.AddToComposition(f)
+						break
+					}
 				}
 			default:
 				declarationType = "alias"

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -587,6 +587,10 @@ func TestIgnoreDirectories(t *testing.T) {
 
 	parser, err = NewClassDiagram([]string{"../testingsupport"}, []string{"../testingsupport/subfolder2"}, true)
 
+	if err != nil {
+		t.Errorf("TestIgnoreDirectories: expected no errors, got %s", err.Error())
+		return
+	}
 	st = parser.getStruct("subfolder2.Subfolder2")
 	if st != nil {
 		t.Errorf("TestIgnoreDirectories: expected st to be nil, got %v", st)
@@ -640,5 +644,19 @@ func TestSetRenderingOptions(t *testing.T) {
 	parser.SetRenderingOptions(newRenderingOptions)
 	if !reflect.DeepEqual(parser.renderingOptions, newRenderingOptions) {
 		t.Errorf("TestRenderingOptions: expected renderingOptions to be %v got %v", newRenderingOptions, parser.renderingOptions)
+	}
+}
+
+func TestRenderCompositionFromInterfaces(t *testing.T) {
+
+	parser, err := NewClassDiagram([]string{"../testingsupport/subfolder"}, []string{}, false)
+
+	if err != nil {
+		t.Errorf("TestIgnoreDirectories: expected no errors, got %s", err.Error())
+		return
+	}
+	st := parser.getStruct("subfolder.test2")
+	if _, ok := st.Composition["subfolder.TestInterfaceAsField"]; !ok {
+		t.Errorf("TestRenderCompositionFromInterfaces: expected st to have a composition dependency to subfolder.TestInterfaceAsField")
 	}
 }

--- a/testingsupport/subfolder/subfolder.go
+++ b/testingsupport/subfolder/subfolder.go
@@ -1,5 +1,9 @@
 package subfolder
 
 type test2 interface {
+	TestInterfaceAsField
 	test()
+}
+
+type TestInterfaceAsField interface {
 }


### PR DESCRIPTION
Fixes #41
Code now adds composition entries when Fields are seen in the interfaces as composition dependencies.