### PR TITLE
Enhancement: Additional CLI options to control rendered -no-methods

### DIFF
--- a/cmd/goplantuml/main.go
+++ b/cmd/goplantuml/main.go
@@ -16,6 +16,7 @@ func main() {
 	ignore := flag.String("ignore", "", "comma separated list of folders to ignore")
 	aggregation := flag.Bool("aggregation", false, "renders public aggregations")
 	hideFields := flag.Bool("hide-fields", false, "hides fields")
+	hideMethods := flag.Bool("hide-methods", false, "hides methods")
 	flag.Parse()
 	dirs, err := getDirectories()
 
@@ -36,6 +37,7 @@ func main() {
 	result.SetRenderingOptions(&goplantuml.RenderingOptions{
 		Aggregation: *aggregation,
 		Fields:      !*hideFields,
+		Methods:     !*hideMethods,
 	})
 	if err != nil {
 		fmt.Println(err.Error())

--- a/parser/class_parser.go
+++ b/parser/class_parser.go
@@ -45,6 +45,7 @@ func (lsb *LineStringBuilder) WriteLineWithDepth(depth int, str string) {
 type RenderingOptions struct {
 	Aggregation bool
 	Fields      bool
+	Methods     bool
 }
 
 //ClassParser contains the structure of the parsed files. The structure is a map of package_names that contains
@@ -66,6 +67,7 @@ func NewClassDiagram(directoryPaths []string, ignoreDirectories []string, recurs
 		renderingOptions: &RenderingOptions{
 			Aggregation: false,
 			Fields:      true,
+			Methods:     true,
 		},
 		structure:     make(map[string]map[string]*Struct),
 		allInterfaces: make(map[string]struct{}),
@@ -287,6 +289,9 @@ func (p *ClassParser) Render() string {
 	}
 	if !p.renderingOptions.Fields {
 		str.WriteLineWithDepth(0, "hide fields")
+	}
+	if !p.renderingOptions.Methods {
+		str.WriteLineWithDepth(0, "hide methods")
 	}
 	str.WriteLineWithDepth(0, "@enduml")
 	return str.String()

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -770,7 +770,8 @@ func TestRenderingOptions(t *testing.T) {
 			Name:        "Show Fields",
 			InputFolder: "../testingsupport/renderingoptions",
 			RenderingOptions: &RenderingOptions{
-				Fields: true,
+				Fields:  true,
+				Methods: true,
 			},
 			ExpectedResult: `@startuml
 namespace renderingoptions {
@@ -789,7 +790,8 @@ namespace renderingoptions {
 			Name:        "Hide Fields",
 			InputFolder: "../testingsupport/renderingoptions",
 			RenderingOptions: &RenderingOptions{
-				Fields: false,
+				Fields:  false,
+				Methods: true,
 			},
 			ExpectedResult: `@startuml
 namespace renderingoptions {
@@ -803,6 +805,48 @@ namespace renderingoptions {
 
 
 hide fields
+@enduml
+`,
+		},
+		{
+			Name:        "Show Methods",
+			InputFolder: "../testingsupport/renderingoptions",
+			RenderingOptions: &RenderingOptions{
+				Fields:  true,
+				Methods: true,
+			},
+			ExpectedResult: `@startuml
+namespace renderingoptions {
+    class Test << (S,Aquamarine) >> {
+        - integer int
+
+        - function() 
+
+    }
+}
+
+
+@enduml
+`,
+		}, {
+			Name:        "Hide Methods",
+			InputFolder: "../testingsupport/renderingoptions",
+			RenderingOptions: &RenderingOptions{
+				Fields:  true,
+				Methods: false,
+			},
+			ExpectedResult: `@startuml
+namespace renderingoptions {
+    class Test << (S,Aquamarine) >> {
+        - integer int
+
+        - function() 
+
+    }
+}
+
+
+hide methods
 @enduml
 `,
 		},


### PR DESCRIPTION
Fixes #54
Decided to use the flag -hide-methods. This will be similar to the way we handled the fields in which we will add the hide methods directive at the end when the options is provided