### PR TITLE
Enhancement: Additional CLI options to control rendered output -no-edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,23 @@ goplantuml [-recursive] path/to/gofiles path/to/gofiles2
 goplantuml [-recursive] path/to/gofiles path/to/gofiles2 > diagram_file_name.puml
 ```
 ```
-goplantuml [-recursive] [-aggregation] [-ignore="path/to/ignored/folder1,path/to/ignore/folder2"] path/to/gofiles > diagram_file_name.puml
+Usage of goplantuml:
+  -hide-connections
+    	hides all connections in the diagram
+  -hide-fields
+    	hides fields
+  -hide-methods
+    	hides methods
+  -ignore string
+    	comma separated list of folders to ignore
+  -recursive
+    	walk all directories recursively
+  -show-aggregation
+    	renders public aggregations
+  -show-compositions
+    	Shows compositions even when -hide-connections is used (default true)
+  -show-implementations
+    	Shows implementations even when -hide-connections is used (default true)
 ```
 
 #### Example

--- a/cmd/goplantuml/main.go
+++ b/cmd/goplantuml/main.go
@@ -14,9 +14,13 @@ import (
 func main() {
 	recursive := flag.Bool("recursive", false, "walk all directories recursively")
 	ignore := flag.String("ignore", "", "comma separated list of folders to ignore")
-	aggregation := flag.Bool("aggregation", false, "renders public aggregations")
+	showAggregations := flag.Bool("show-aggregation", false, "renders public aggregations")
 	hideFields := flag.Bool("hide-fields", false, "hides fields")
 	hideMethods := flag.Bool("hide-methods", false, "hides methods")
+	hideConnections := flag.Bool("hide-connections", false, "hides all connections in the diagram")
+	showCompositions := flag.Bool("show-compositions", true, "Shows compositions even when -hide-connections is used")
+	showImplementations := flag.Bool("show-implementations", true, "Shows implementations even when -hide-connections is used")
+
 	flag.Parse()
 	dirs, err := getDirectories()
 
@@ -35,9 +39,11 @@ func main() {
 
 	result, err := goplantuml.NewClassDiagram(dirs, ignoredDirectories, *recursive)
 	result.SetRenderingOptions(&goplantuml.RenderingOptions{
-		Aggregation: *aggregation,
-		Fields:      !*hideFields,
-		Methods:     !*hideMethods,
+		Aggregations:    *showAggregations && !*hideConnections,
+		Fields:          !*hideFields,
+		Methods:         !*hideMethods,
+		Compositions:    *showCompositions && !*hideConnections,
+		Implementations: *showImplementations && !*hideConnections,
 	})
 	if err != nil {
 		fmt.Println(err.Error())

--- a/parser/class_parser.go
+++ b/parser/class_parser.go
@@ -43,9 +43,12 @@ func (lsb *LineStringBuilder) WriteLineWithDepth(depth int, str string) {
 
 //RenderingOptions will allow the class parser to optionally enebale or disable the things to render.
 type RenderingOptions struct {
-	Aggregation bool
-	Fields      bool
-	Methods     bool
+	Aggregations    bool
+	Fields          bool
+	Methods         bool
+	Compositions    bool
+	Implementations bool
+	Aliases         bool
 }
 
 //ClassParser contains the structure of the parsed files. The structure is a map of package_names that contains
@@ -65,9 +68,12 @@ type ClassParser struct {
 func NewClassDiagram(directoryPaths []string, ignoreDirectories []string, recursive bool) (*ClassParser, error) {
 	classParser := &ClassParser{
 		renderingOptions: &RenderingOptions{
-			Aggregation: false,
-			Fields:      true,
-			Methods:     true,
+			Aggregations:    false,
+			Fields:          true,
+			Methods:         true,
+			Compositions:    true,
+			Implementations: true,
+			Aliases:         true,
 		},
 		structure:     make(map[string]map[string]*Struct),
 		allInterfaces: make(map[string]struct{}),
@@ -284,9 +290,6 @@ func (p *ClassParser) Render() string {
 		p.renderStructures(pack, structures, str)
 
 	}
-	for name, alias := range p.allAliases {
-		renderAlias(name, alias, str)
-	}
 	if !p.renderingOptions.Fields {
 		str.WriteLineWithDepth(0, "hide fields")
 	}
@@ -307,10 +310,19 @@ func (p *ClassParser) renderStructures(pack string, structures map[string]*Struc
 			p.renderStructure(structure, pack, name, str, composition, extends, aggregations)
 		}
 		str.WriteLineWithDepth(0, fmt.Sprintf(`}`))
-		str.WriteLineWithDepth(0, composition.String())
-		str.WriteLineWithDepth(0, extends.String())
-		if p.renderingOptions.Aggregation {
+		if p.renderingOptions.Compositions {
+			str.WriteLineWithDepth(0, composition.String())
+		}
+		if p.renderingOptions.Implementations {
+			str.WriteLineWithDepth(0, extends.String())
+		}
+		if p.renderingOptions.Aggregations {
 			str.WriteLineWithDepth(0, aggregations.String())
+		}
+		if p.renderingOptions.Aliases {
+			for name, alias := range p.allAliases {
+				renderAlias(name, alias, str)
+			}
 		}
 	}
 }

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -199,7 +199,12 @@ func TestRenderStructures(t *testing.T) {
 	lineB = &LineStringBuilder{}
 	parser = getEmptyParser("main")
 	parser.SetRenderingOptions(&RenderingOptions{
-		Aggregation: true,
+		Aggregations:    true,
+		Fields:          true,
+		Methods:         true,
+		Compositions:    true,
+		Implementations: true,
+		Aliases:         true,
 	})
 	parser.renderStructures("main", structMap, lineB)
 	expectedResult = "namespace main {\n    class MainClass << (S,Aquamarine) >> {\n        - privateField int\n\n        + PublicField error\n\n        - foo( int,  string) (error, int)\n\n        + Boo( string,  int) int\n\n    }\n}\n\"foopack.AnotherClass\" *-- \"main.MainClass\"\n\n\"main.NewClass\" <|-- \"main.MainClass\"\n\n\"main.MainClass\" o-- \"main.File\"\n\n"
@@ -401,7 +406,14 @@ func TestRenderStructMethods(t *testing.T) {
 
 func getEmptyParser(packageName string) *ClassParser {
 	result := &ClassParser{
-		renderingOptions:   &RenderingOptions{},
+		renderingOptions: &RenderingOptions{
+			Aggregations:    false,
+			Fields:          true,
+			Methods:         true,
+			Compositions:    true,
+			Implementations: true,
+			Aliases:         true,
+		},
 		currentPackageName: packageName,
 		structure:          make(map[string]map[string]*Struct),
 		allInterfaces:      make(map[string]struct{}),
@@ -607,7 +619,7 @@ func TestRenderAggregations(t *testing.T) {
 			"File": {},
 		},
 	}
-	parser.renderingOptions.Aggregation = true
+	parser.renderingOptions.Aggregations = true
 	aggregationsBuilder := &LineStringBuilder{}
 	parser.renderAggregations(st, "TestClass", aggregationsBuilder)
 	expectedResult := "\"main.TestClass\" o-- \"main.File\"\n"
@@ -624,7 +636,7 @@ func TestRenderAggregations(t *testing.T) {
 			},
 		},
 	}
-	parser.renderingOptions.Aggregation = true
+	parser.renderingOptions.Aggregations = true
 	aggregationsBuilder = &LineStringBuilder{}
 	parser.renderAggregations(st, "TestClass", aggregationsBuilder)
 	expectedResult = ""
@@ -635,12 +647,19 @@ func TestRenderAggregations(t *testing.T) {
 
 func TestSetRenderingOptions(t *testing.T) {
 	parser := getEmptyParser("main")
-	emptyRenderingOptions := &RenderingOptions{}
+	emptyRenderingOptions := &RenderingOptions{
+		Aggregations:    false,
+		Fields:          true,
+		Methods:         true,
+		Compositions:    true,
+		Implementations: true,
+		Aliases:         true,
+	}
 	if !reflect.DeepEqual(parser.renderingOptions, emptyRenderingOptions) {
 		t.Errorf("TestRenderingOptions: expected renderingOptions to be %v got %v", emptyRenderingOptions, parser.renderingOptions)
 	}
 	newRenderingOptions := &RenderingOptions{
-		Aggregation: true,
+		Aggregations: true,
 	}
 	parser.SetRenderingOptions(newRenderingOptions)
 	if !reflect.DeepEqual(parser.renderingOptions, newRenderingOptions) {
@@ -770,8 +789,12 @@ func TestRenderingOptions(t *testing.T) {
 			Name:        "Show Fields",
 			InputFolder: "../testingsupport/renderingoptions",
 			RenderingOptions: &RenderingOptions{
-				Fields:  true,
-				Methods: true,
+				Aggregations:    false,
+				Fields:          true,
+				Methods:         true,
+				Compositions:    true,
+				Implementations: true,
+				Aliases:         true,
 			},
 			ExpectedResult: `@startuml
 namespace renderingoptions {
@@ -790,8 +813,12 @@ namespace renderingoptions {
 			Name:        "Hide Fields",
 			InputFolder: "../testingsupport/renderingoptions",
 			RenderingOptions: &RenderingOptions{
-				Fields:  false,
-				Methods: true,
+				Aggregations:    false,
+				Fields:          false,
+				Methods:         true,
+				Compositions:    true,
+				Implementations: true,
+				Aliases:         true,
 			},
 			ExpectedResult: `@startuml
 namespace renderingoptions {
@@ -812,8 +839,12 @@ hide fields
 			Name:        "Show Methods",
 			InputFolder: "../testingsupport/renderingoptions",
 			RenderingOptions: &RenderingOptions{
-				Fields:  true,
-				Methods: true,
+				Aggregations:    false,
+				Fields:          true,
+				Methods:         true,
+				Compositions:    true,
+				Implementations: true,
+				Aliases:         true,
 			},
 			ExpectedResult: `@startuml
 namespace renderingoptions {
@@ -832,8 +863,12 @@ namespace renderingoptions {
 			Name:        "Hide Methods",
 			InputFolder: "../testingsupport/renderingoptions",
 			RenderingOptions: &RenderingOptions{
-				Fields:  true,
-				Methods: false,
+				Aggregations:    false,
+				Fields:          true,
+				Methods:         false,
+				Compositions:    true,
+				Implementations: true,
+				Aliases:         true,
 			},
 			ExpectedResult: `@startuml
 namespace renderingoptions {


### PR DESCRIPTION
Fixes #55
I made this with the flag -hide-connections
The result would be that aggregations, compositions, and interface implementations will not be added. However, if the flags -show-aggregations, -show-compositions, or -show-implementations are provided, the user can toggle these on demand.
These three last flags will only make a difference if the user pass them along with the -hide-connections flag

This also altered the aggregations flag, its now -show-aggregations for consistency, and it defaults to false. The other show flags default to true.