### PR TITLE
panic: runtime error: index out of range at class_parser.go:196

### DIFF
--- a/parser/class_parser.go
+++ b/parser/class_parser.go
@@ -204,7 +204,10 @@ func (p *ClassParser) handleFuncDecl(decl *ast.FuncDecl) {
 }
 
 func (p *ClassParser) handleGenDecl(decl *ast.GenDecl) {
-
+	if decl.Specs == nil || len(decl.Specs) < 1 {
+		//This might be a type of General Declaration we do not know how to handle.
+		return
+	}
 	spec := decl.Specs[0]
 	var typeName string
 	var alias *Alias

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -901,3 +901,16 @@ hide methods
 		})
 	}
 }
+
+func TestHandleGenDecl(t *testing.T) {
+	parser := getEmptyParser("main")
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("TestHandleGenDecl: Expected no panic in this function when the Specs are empty or nil.")
+		}
+	}()
+	parser.handleGenDecl(&ast.GenDecl{})
+	parser.handleGenDecl(&ast.GenDecl{
+		Specs: []ast.Spec{},
+	})
+}


### PR DESCRIPTION
Fixes #64
Added preventive code to make sure we do not panic when the Specs in the GenDecl is nil or empty