### PR TITLE
Invalid edge for type

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Usage of goplantuml:
     	comma separated list of folders to ignore
   -recursive
     	walk all directories recursively
-  -show-aggregation
+  -show-aggregations
     	renders public aggregations
+  -show-aliases
+    	Shows aliases even when -hide-connections is used (default true)
   -show-compositions
     	Shows compositions even when -hide-connections is used (default true)
   -show-implementations

--- a/cmd/goplantuml/main.go
+++ b/cmd/goplantuml/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	recursive := flag.Bool("recursive", false, "walk all directories recursively")
 	ignore := flag.String("ignore", "", "comma separated list of folders to ignore")
-	showAggregations := flag.Bool("show-aggregation", false, "renders public aggregations")
+	showAggregations := flag.Bool("show-aggregations", false, "renders public aggregations")
 	hideFields := flag.Bool("hide-fields", false, "hides fields")
 	hideMethods := flag.Bool("hide-methods", false, "hides methods")
 	hideConnections := flag.Bool("hide-connections", false, "hides all connections in the diagram")

--- a/parser/class_parser.go
+++ b/parser/class_parser.go
@@ -301,6 +301,11 @@ func (p *ClassParser) Render() string {
 		p.renderStructures(pack, structures, str)
 
 	}
+	if p.renderingOptions.Aliases {
+		for name, alias := range p.allAliases {
+			renderAlias(name, alias, str)
+		}
+	}
 	if !p.renderingOptions.Fields {
 		str.WriteLineWithDepth(0, "hide fields")
 	}
@@ -329,11 +334,6 @@ func (p *ClassParser) renderStructures(pack string, structures map[string]*Struc
 		}
 		if p.renderingOptions.Aggregations {
 			str.WriteLineWithDepth(0, aggregations.String())
-		}
-		if p.renderingOptions.Aliases {
-			for name, alias := range p.allAliases {
-				renderAlias(name, alias, str)
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #49
The alias rendering needed to be at a level above since it was a more global rendering. Not at the level of the package. If you have more than one package this was rendering that many times.