### PR TITLE
Enhancement: Additional CLI options to control rendered output -label-edges

### DIFF
--- a/ClassDiagram.puml
+++ b/ClassDiagram.puml
@@ -22,6 +22,7 @@ namespace parser {
         - handleFuncDecl(decl *ast.FuncDecl) 
         - handleGenDecl(decl *ast.GenDecl) 
         - renderStructures(pack string, structures <font color=blue>map</font>[string]*Struct, str *LineStringBuilder) 
+        - renderAliases(str *LineStringBuilder) 
         - renderStructure(structure *Struct, pack string, name string, str *LineStringBuilder, composition *LineStringBuilder, extends *LineStringBuilder, aggregations *LineStringBuilder) 
         - renderCompositions(structure *Struct, name string, composition *LineStringBuilder) 
         - renderAggregations(structure *Struct, name string, aggregations *LineStringBuilder) 
@@ -33,7 +34,7 @@ namespace parser {
         - getStruct(structName string) *Struct
 
         + Render() string
-        + SetRenderingOptions(ro *RenderingOptions) 
+        + SetRenderingOptions(ro <font color=blue>map</font>[RenderingOption]bool) error
 
     }
     class Field << (S,Aquamarine) >> {
@@ -63,6 +64,7 @@ namespace parser {
         + Compositions bool
         + Implementations bool
         + Aliases bool
+        + ConnectionLabels bool
 
     }
     class Struct << (S,Aquamarine) >> {
@@ -82,12 +84,15 @@ namespace parser {
         + AddMethod(method *ast.Field, aliases <font color=blue>map</font>[string]string) 
 
     }
+    class parser.RenderingOption << (T, #FF7700) >>  {
+    }
 }
-"strings.Builder" *-- "parser.LineStringBuilder"
+"strings.Builder" *-- "extends""parser.LineStringBuilder"
 
 
-"parser.Function" o-- "parser.Field"
-"parser.Struct" o-- "parser.Field"
-"parser.Struct" o-- "parser.Function"
+"parser.Function""uses" o-- "parser.Field"
+"parser.Struct""uses" o-- "parser.Field"
+"parser.Struct""uses" o-- "parser.Function"
 
+"__builtin__.int" #.. "alias of""parser.RenderingOption"
 @enduml

--- a/README.md
+++ b/README.md
@@ -34,23 +34,25 @@ goplantuml [-recursive] path/to/gofiles path/to/gofiles2 > diagram_file_name.pum
 ```
 Usage of goplantuml:
   -hide-connections
-    	hides all connections in the diagram
+        hides all connections in the diagram
   -hide-fields
-    	hides fields
+        hides fields
   -hide-methods
-    	hides methods
+        hides methods
   -ignore string
-    	comma separated list of folders to ignore
+        comma separated list of folders to ignore
   -recursive
-    	walk all directories recursively
+        walk all directories recursively
   -show-aggregations
-    	renders public aggregations
+        renders public aggregations even when -hide-connections is used (do not render by default)
   -show-aliases
-    	Shows aliases even when -hide-connections is used (default true)
+        Shows aliases even when -hide-connections is used
   -show-compositions
-    	Shows compositions even when -hide-connections is used (default true)
+        Shows compositions even when -hide-connections is used
+  -show-connection-labels
+        Shows labels in the connections to identify the connections types (e.g. extends, implements, aggregates, alias of
   -show-implementations
-    	Shows implementations even when -hide-connections is used (default true)
+        Shows implementations even when -hide-connections is used
 ```
 
 #### Example

--- a/generate_diagram
+++ b/generate_diagram
@@ -1,2 +1,2 @@
 #!/bin/bash
-go install ./... && goplantuml -show-aggregations -recursive -ignore="./testingsupport/"  ./parser > ClassDiagram.puml
+go install ./... && goplantuml -show-connection-labels -show-aggregations -recursive -ignore="./testingsupport/"  ./parser > ClassDiagram.puml

--- a/testingsupport/connectionlabels/connectionlabels.go
+++ b/testingsupport/connectionlabels/connectionlabels.go
@@ -1,0 +1,19 @@
+package connectionlabels
+
+//AbstractInterface for testing purposes
+type AbstractInterface interface {
+	interfaceFunction() bool
+}
+
+//ImplementsAbstractInterface for testing purposes
+type ImplementsAbstractInterface struct {
+	AliasOfInt
+	PublicUse AbstractInterface
+}
+
+func (iai *ImplementsAbstractInterface) interfaceFunction() bool {
+	return true
+}
+
+//AliasOfInt for testing purposes
+type AliasOfInt int


### PR DESCRIPTION
Fixes #58
In implementing this, I decided to use the -show-connection-labels for consistency with other flags. I also realized that the SetRenderingOptions what going to be a problem for testing so I changed its parameter to be a map[RenderingOption] bool where the RenderingOption is no more than an int for which we have provided a set of constants.
I also updated the Readme and the class diagram to reflect this new options.