### PR TITLE
Change the Parser to accept a file directory interface as the directo…

### DIFF
--- a/ClassDiagram.puml
+++ b/ClassDiagram.puml
@@ -6,6 +6,14 @@ namespace parser {
         + AliasOf string
 
     }
+    class ClassDiagramOptions << (S,Aquamarine) >> {
+        + FileSystem afero.Fs
+        + Directories []string
+        + IgnoredDirectories []string
+        + RenderingOptions <font color=blue>map</font>[RenderingOption]bool
+        + Recursive bool
+
+    }
     class ClassParser << (S,Aquamarine) >> {
         - renderingOptions *RenderingOptions
         - structure <font color=blue>map</font>[string]<font color=blue>map</font>[string]*Struct
@@ -90,6 +98,8 @@ namespace parser {
 "strings.Builder" *-- "extends""parser.LineStringBuilder"
 
 
+"parser.ClassDiagramOptions""uses" o-- "afero.Fs"
+"parser.ClassDiagramOptions""uses" o-- "parser.RenderingOption"
 "parser.Function""uses" o-- "parser.Field"
 "parser.Struct""uses" o-- "parser.Field"
 "parser.Struct""uses" o-- "parser.Function"

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -945,3 +945,18 @@ namespace connectionlabels {
 	}
 
 }
+
+func TestNewClassDiagramWithOptions(t *testing.T) {
+	options := &ClassDiagramOptions{
+		RenderingOptions: map[RenderingOption]bool{
+			RenderAggregations: true,
+		},
+	}
+	parser, err := NewClassDiagramWithOptions(options)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if parser.renderingOptions.Aggregations != true {
+		t.Errorf("TestNewClassDiagramWithOptions: Expected Aggregations to be true got false")
+	}
+}


### PR DESCRIPTION
…ries of the project instead of a string.

Fixes #48
Used the afero.Fs interface to allow for this. Now users of the library can implement this interface if they want to redirect this to a different FileSystem. The previous NewClassDiagram function is still supported and will, by default, inject the osFs into the options.