### PR TITLE
Some complicated constructs render incorrectly

### DIFF
--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -413,6 +413,8 @@ func getEmptyParser(packageName string) *ClassParser {
 		structure:          make(map[string]map[string]*Struct),
 		allInterfaces:      make(map[string]struct{}),
 		allStructs:         make(map[string]struct{}),
+		allAliases:         make(map[string]*Alias),
+		allRenamedStructs:  make(map[string]map[string]string),
 	}
 	result.structure[packageName] = make(map[string]*Struct)
 	return result
@@ -958,5 +960,12 @@ func TestNewClassDiagramWithOptions(t *testing.T) {
 	}
 	if parser.renderingOptions.Aggregations != true {
 		t.Errorf("TestNewClassDiagramWithOptions: Expected Aggregations to be true got false")
+	}
+}
+
+func TestGenerateRenamedStructName(t *testing.T) {
+	generatedName := generateRenamedStructName(`a#b%c.d`)
+	if generatedName != "abcd" {
+		t.Errorf("TestGenerateRenamedStructName: Expected result to be abcd, got %s", generatedName)
 	}
 }

--- a/testingsupport/main.go
+++ b/testingsupport/main.go
@@ -1,6 +1,9 @@
 package testingsupport
 
-import f "fmt"
+import (
+	f "fmt"
+	"strings"
+)
 
 func (t *test) test() {
 	f.Println("Hello Test")
@@ -13,3 +16,6 @@ type test struct {
 type myInt int
 
 var globalVariable int
+
+//TestComplicatedAlias for testing purposes only
+type TestComplicatedAlias func(strings.Builder) bool

--- a/testingsupport/testingsupport.puml
+++ b/testingsupport/testingsupport.puml
@@ -6,10 +6,16 @@ namespace testingsupport {
         - test() 
 
     }
+    class testingsupport.TestComplicatedAlias << (T, #FF7700) >>  {
+    }
     class testingsupport.myInt << (T, #FF7700) >>  {
+    }
+    class "<font color=blue>func</font>(strings.Builder) bool" as fontcolorbluefuncfontstringsBuilderbool {
+        'This class was created so that we can correctly have an alias pointing to this name. Since it contains dots that can break namespaces
     }
 }
 
 
 "__builtin__.int" #.. "testingsupport.myInt"
+"testingsupport.fontcolorbluefuncfontstringsBuilderbool" #.. "testingsupport.TestComplicatedAlias"
 @enduml


### PR DESCRIPTION
Fixes #74
I had to create a temp class inside the namespace for the class with the complicated dot inclusive name but renamed with just alphanumeric characters so that we can use it in the alias rendering without the dots. Or rather with just the package name dot expression. This seems to do the trick for these type of instances.