### PR TITLE
Init go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-.idea
+.idea/
+.vscode/
+
+vendor/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  deadline: 210s
+  modules-download-mode: vendor
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - golint
+    - gocyclo
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: github.com/jfeliu007/goplantuml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 language: go
 
 go:
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
+  - 1.16.x
+
+env:
+  global: GO111MODULE=on
 
 before_install:
-  - go mod download
+  - go mod vendor
   - go get -u golang.org/x/lint/golint
   - go get github.com/fzipp/gocyclo/cmd/gocyclo
 
 script:
-  - go test ./parser -coverprofile=coverage.txt -covermode=atomic
+  - go test -mod=vendor ./parser -coverprofile=coverage.txt -covermode=atomic
+  - rm -rf vendor/
   - golint -set_exit_status ./...
   - gocyclo -over 15 ./parser
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,11 @@ env:
 
 before_install:
   - go mod vendor
-  - go get -u golang.org/x/lint/golint
-  - go get github.com/fzipp/gocyclo/cmd/gocyclo
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.38.1
 
 script:
   - go test -mod=vendor ./parser -coverprofile=coverage.txt -covermode=atomic
-  - rm -rf vendor/
-  - golint -set_exit_status ./...
-  - gocyclo -over 15 ./parser
+  - golangci-lint run ./...
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ go:
   - 1.11.x
 
 before_install:
-  - go get -t -v ./...
+  - go mod download
   - go get -u golang.org/x/lint/golint
   - go get github.com/fzipp/gocyclo/cmd/gocyclo
+
 script:
   - go test ./parser -coverprofile=coverage.txt -covermode=atomic
   - golint -set_exit_status ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 before_install:
   - go mod vendor
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.38.1
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.38.0
 
 script:
   - go test -mod=vendor ./parser -coverprofile=coverage.txt -covermode=atomic

--- a/README.md
+++ b/README.md
@@ -14,15 +14,12 @@ Take a look at [www.dumels.com](https://www.dumels.com). We have created dumels 
 Please, review the code of conduct [here](https://github.com/jfeliu007/goplantuml/blob/master/CODE_OF_CONDUCT.md "here").
 
 ### Prerequisites
-golang 1.10 or above
+golang 1.12 or above
 
 ### Installing
 
 ```
-go get github.com/jfeliu007/goplantuml/parser
-go get github.com/jfeliu007/goplantuml/cmd/goplantuml
-cd $GOPATH/src/github.com/jfeliu007/goplantuml
-go install ./...
+go get github.com/jfeliu007/goplantuml/v2/cmd/goplantuml
 ```
 
 This will install the command goplantuml in your GOPATH bin folder.
@@ -130,7 +127,7 @@ strings.Builder *-- parser.LineStringBuilder
 ```
 ```
 goplantuml $GOPATH/src/github.com/jfeliu007/goplantuml/parser > ClassDiagram.puml
-// Generates a file ClassDiagram.plum with the previous specifications
+// Generates a file ClassDiagram.puml with the previous specifications
 ```
 
 There are two different relationships considered in goplantuml:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 [![godoc reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/jfeliu007/goplantuml/parser) [![Go Report Card](https://goreportcard.com/badge/github.com/jfeliu007/goplantuml)](https://goreportcard.com/report/github.com/jfeliu007/goplantuml) [![codecov](https://codecov.io/gh/jfeliu007/goplantuml/branch/master/graph/badge.svg)](https://codecov.io/gh/jfeliu007/goplantuml) [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![GitHub release](https://img.shields.io/github/release/jfeliu007/goplantuml.svg)](https://github.com/jfeliu007/goplantuml/releases/)
 [![Build Status](https://travis-ci.org/jfeliu007/goplantuml.svg?branch=master)](https://travis-ci.org/jfeliu007/goplantuml)
-[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go) 
-[![DUMELS Diagram](https://www.dumels.com/api/v1/badge/23ff0222-e93b-4e9f-a4ef-4d5d9b7a5c7d)](https://www.dumels.com/diagram/23ff0222-e93b-4e9f-a4ef-4d5d9b7a5c7d) 
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
+[![DUMELS Diagram](https://www.dumels.com/api/v1/badge/23ff0222-e93b-4e9f-a4ef-4d5d9b7a5c7d)](https://www.dumels.com/diagram/23ff0222-e93b-4e9f-a4ef-4d5d9b7a5c7d)
 # GoPlantUML
 
 PlantUML Class Diagram Generator for golang projects. Generates class diagram text compatible with plantuml with the information of all structures and interfaces as well as the relationship among them.
 
-## Want to try it on your code? 
-Take a look at [www.dumels.com](https://www.dumels.com). We have created dumels using this library. 
+## Want to try it on your code?
+Take a look at [www.dumels.com](https://www.dumels.com). We have created dumels using this library.
 
 ## Code of Conduct
 Please, review the code of conduct [here](https://github.com/jfeliu007/goplantuml/blob/master/CODE_OF_CONDUCT.md "here").
 
 ### Prerequisites
-golang 1.12 or above
+golang 1.14 or above
 
 ### Installing
 
@@ -84,7 +84,7 @@ namespace parser {
 
     }
     class LineStringBuilder {
-        + WriteLineWithDepth(depth int, str string) 
+        + WriteLineWithDepth(depth int, str string)
 
     }
     class ClassParser {
@@ -93,19 +93,19 @@ namespace parser {
         - allInterfaces <font color=blue>map</font>[string]<font color=blue>struct</font>{}
         - allStructs <font color=blue>map</font>[string]<font color=blue>struct</font>{}
 
-        - structImplementsInterface(st *Struct, inter *Struct) 
-        - parsePackage(node ast.Node) 
-        - parseFileDeclarations(node ast.Decl) 
-        - addMethodToStruct(s *Struct, method *ast.Field) 
-        - getFunction(f *ast.FuncType, name string) 
-        - addFieldToStruct(s *Struct, field *ast.Field) 
-        - addToComposition(s *Struct, fType string) 
-        - addToExtends(s *Struct, fType string) 
-        - getOrCreateStruct(name string) 
-        - getStruct(structName string) 
-        - getFieldType(exp ast.Expr, includePackageName bool) 
+        - structImplementsInterface(st *Struct, inter *Struct)
+        - parsePackage(node ast.Node)
+        - parseFileDeclarations(node ast.Decl)
+        - addMethodToStruct(s *Struct, method *ast.Field)
+        - getFunction(f *ast.FuncType, name string)
+        - addFieldToStruct(s *Struct, field *ast.Field)
+        - addToComposition(s *Struct, fType string)
+        - addToExtends(s *Struct, fType string)
+        - getOrCreateStruct(name string)
+        - getStruct(structName string)
+        - getFieldType(exp ast.Expr, includePackageName bool)
 
-        + Render() 
+        + Render()
 
     }
     class Parameter {
@@ -180,7 +180,7 @@ namespace testingsupport {
     class MyStruct2 << (S,Aquamarine) >> {
     }
     class MyStruct3 << (S,Aquamarine) >> {
-        - foo() 
+        - foo()
 
         + Foo MyStruct1
 

--- a/cmd/goplantuml/main.go
+++ b/cmd/goplantuml/main.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	goplantuml "github.com/jfeliu007/goplantuml/parser"
+	goplantuml "github.com/jfeliu007/goplantuml/v2/parser"
 )
 
 //RenderingOptionSlice will implements the sort interface

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jfeliu007/goplantuml/v2
 
-go 1.12
+go 1.14
 
 require github.com/spf13/afero v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jfeliu007/goplantuml/v2
+
+go 1.12
+
+require github.com/spf13/afero v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jfeliu007/goplantuml/v2
 
-go 1.14
+go 1.11
 
 require github.com/spf13/afero v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/testingsupport/vendor/.keep
+++ b/testingsupport/vendor/.keep
@@ -1,1 +1,0 @@
-this file is to keep the vendors forlder in git 


### PR DESCRIPTION
Move to go modules with v2 and update readme and travis accordingly.

Bump supported go versions from go1.11 to latest.

Resolves #31.