### PR TITLE
Fix error from named imports and anonymous fields

### DIFF
--- a/parser/class_parser.go
+++ b/parser/class_parser.go
@@ -239,7 +239,7 @@ func (p *ClassParser) parsePackage(node ast.Node) {
 func (p *ClassParser) parseImports(impt *ast.ImportSpec) {
 	if impt.Name != nil {
 		splitPath := strings.Split(impt.Path.Value, "/")
-		s := strings.TrimRight(splitPath[len(splitPath)-1], `"`)
+		s := strings.Trim(splitPath[len(splitPath)-1], `"`)
 		p.allImports[impt.Name.Name] = s
 	}
 }

--- a/parser/class_parser_test.go
+++ b/parser/class_parser_test.go
@@ -907,8 +907,8 @@ hide methods
 @enduml
 `,
 		}, {
-			Name:        "Hide Private Members",
-			InputFolder: "../testingsupport/renderingoptions",
+			Name:             "Hide Private Members",
+			InputFolder:      "../testingsupport/renderingoptions",
 			RenderingOptions: map[RenderingOption]interface{}{},
 			ExpectedResult: `@startuml
 namespace renderingoptions {
@@ -1051,6 +1051,30 @@ namespace parenthesizedtypedeclarations {
 `
 	if result != expectedResult {
 		t.Errorf("TestConnectionLabelsRendering: expecting \n%s\n got \n%s\n", expectedResult, result)
+	}
+
+}
+
+func TestNamedImportsInAnonymousFields(t *testing.T) {
+	parser, err := NewClassDiagram([]string{"../testingsupport/namedimports"}, []string{}, false)
+	if err != nil {
+		t.Errorf("TestNamedImportsInAnonymousFields: expected no error but got %s", err.Error())
+		return
+	}
+	parser.SetRenderingOptions(map[RenderingOption]interface{}{})
+	result := parser.Render()
+	expectedResult := `@startuml
+namespace namedimports {
+    class MyType << (S,Aquamarine) >> {
+    }
+}
+"time.Duration" *-- "namedimports.MyType"
+
+
+@enduml
+`
+	if result != expectedResult {
+		t.Errorf("TestNamedImportsInAnonymousFields: expecting \n%s\n got \n%s\n", expectedResult, result)
 	}
 
 }

--- a/testingsupport/namedimports/namedimports.go
+++ b/testingsupport/namedimports/namedimports.go
@@ -1,0 +1,9 @@
+package namedimports
+
+import time "time"
+
+// MyType for testing purposes when a named import is used as an anonymous
+// field.
+type MyType struct {
+	*time.Duration
+}


### PR DESCRIPTION
Members of named imports used as anonymous fields in structs will
cause a syntax error where the named field is prefixed with an
extraneous double quote.

Fixed by trimming double quotes from both sides of the import.

Fixes #123

Signed-off-by: Christopher Sams <cwsams@gmail.com>