### PR TITLE
Updated install instructions to "go install" per issue 119

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ golang 1.10 or above
 
 ```
 go get github.com/jfeliu007/goplantuml/parser
-go get github.com/jfeliu007/goplantuml/cmd/goplantuml
-cd $GOPATH/src/github.com/jfeliu007/goplantuml
-go install ./...
+go install github.com/jfeliu007/goplantuml/cmd/goplantuml@latest
 ```
 
 This will install the command goplantuml in your GOPATH bin folder.


### PR DESCRIPTION
Per issue 119: Changed install instructions from "go get" to "go install" on line 23. Removed the following 2 lines which are now redundant.
"go get" is deprecated: "installing executables with 'go get' in module mode is deprecated."